### PR TITLE
Add BM1370 stub driver

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,6 +135,10 @@ cgminer_SOURCES += dm_fan_ctrl.c
 cgminer_SOURCES += dm_compat.c
 endif
 
+if HAS_BM1370
+cgminer_SOURCES += driver-bm1370.c driver-bm1370.h
+endif
+
 if HAS_DRILLBIT
 cgminer_SOURCES += driver-drillbit.c driver-drillbit.h
 endif

--- a/README
+++ b/README
@@ -137,8 +137,10 @@ CGMiner specific configuration options:
   --enable-bitfury        Compile support for BitFury ASICs (default disabled)
   --enable-bitmine_A1     Compile support for Bitmine.ch A1 ASICs (default
                           disabled)
+  --enable-bm1370         Compile support for BM1370 ASICs (default
+                          disabled)
   --enable-blockerupter   Compile support for ASICMINER BlockErupter Tube/Prisma
-  			  (default disabled)
+                          (default disabled)
   --enable-cointerra      Compile support for Cointerra ASICs (default disabled)
   --enable-drillbit       Compile support for Drillbit BitFury ASICs (default
                           disabled)

--- a/configure.ac
+++ b/configure.ac
@@ -411,6 +411,19 @@ fi
 AM_CONDITIONAL([HAS_DRAGONMINT_T1], [test x$dragonmint_t1 = xyes])
 
 
+bm1370="no"
+
+AC_ARG_ENABLE([bm1370],
+        [AC_HELP_STRING([--enable-bm1370],[Compile support for BM1370 ASICs STANDALONE(default disabled)])],
+        [bm1370=$enableval]
+        )
+if test "x$bm1370" = xyes; then
+        AC_DEFINE([USE_BM1370], [1], [Defined to 1 if BM1370 support is wanted])
+        drivercount=x$drivercount
+        standalone="yes"
+fi
+AM_CONDITIONAL([HAS_BM1370], [test x$bm1370 = xyes])
+
 drillbit="no"
 
 AC_ARG_ENABLE([drillbit],
@@ -931,9 +944,15 @@ else
 fi
 
 if test "x$dragonmint_t1" = xyes; then
-	echo "  Dragonmint.T1.ASICs..: Enabled"
+        echo "  Dragonmint.T1.ASICs..: Enabled"
 else
-	echo "  Dragonmint.T1.ASICs..: Disabled"
+        echo "  Dragonmint.T1.ASICs..: Disabled"
+fi
+
+if test "x$bm1370" = xyes; then
+        echo "  BM1370.ASICs........: Enabled"
+else
+        echo "  BM1370.ASICs........: Disabled"
 fi
 
 if test "x$drillbit" = xyes; then
@@ -979,7 +998,7 @@ else
 fi
 
 #Add any new device to this, along with a no on the end of the test
-if test "x$avalon$avalon2$avalon4$avalon7$avalon8$avalon_miner$bab$bflsc$bitforce$bitfury$bitfury16$bitmain_soc$blockerupter$hashfast$hashratio$icarus$klondike$knc$modminer$drillbit$minion$cointerra$bitmine_A1$ants1$ants2$ants3$sp10$sp30$dragonmint_t1" = xnononononononononononononononononononononononononononono; then
+if test "x$avalon$avalon2$avalon4$avalon7$avalon8$avalon_miner$bab$bflsc$bitforce$bitfury$bitfury16$bitmain_soc$blockerupter$hashfast$hashratio$icarus$klondike$knc$modminer$drillbit$minion$cointerra$bitmine_A1$ants1$ants2$ants3$sp10$sp30$dragonmint_t1$bm1370" = xnonononononononononononononononononononononononononononon; then
 	echo
 	AC_MSG_ERROR([No mining devices configured in])
 	echo

--- a/driver-bm1370.c
+++ b/driver-bm1370.c
@@ -1,0 +1,26 @@
+#include "config.h"
+#include "miner.h"
+#include "logging.h"
+#include "driver-bm1370.h"
+
+/*
+ * Stub driver for BM1370 ASIC based on ESP-Miner reference implementation.
+ * This only implements minimal hooks required by cgminer and does not
+ * support real hardware interaction. It serves as a placeholder for future
+ * development.
+ */
+
+static void bm1370_detect(__maybe_unused bool hotplug)
+{
+    applog(LOG_INFO, "BM1370 driver stub loaded");
+}
+
+struct device_drv bm1370_drv = {
+    .drv_id    = DRIVER_bm1370,
+    .dname     = "BM1370",
+    .name      = "BM1370",
+    .drv_detect = bm1370_detect,
+    .hash_work  = hash_driver_work,
+    .get_statline_before = blank_get_statline_before,
+};
+

--- a/driver-bm1370.h
+++ b/driver-bm1370.h
@@ -1,0 +1,6 @@
+#ifndef DRIVER_BM1370_H
+#define DRIVER_BM1370_H
+
+#include "miner.h"
+
+#endif // DRIVER_BM1370_H

--- a/miner.h
+++ b/miner.h
@@ -257,9 +257,10 @@ static inline int fsync (int fd)
 	DRIVER_ADD_COMMAND(bitfury16) \
 	DRIVER_ADD_COMMAND(bitmineA1) \
 	DRIVER_ADD_COMMAND(blockerupter) \
-	DRIVER_ADD_COMMAND(cointerra) \
-	DRIVER_ADD_COMMAND(dragonmintT1) \
-	DRIVER_ADD_COMMAND(hashfast) \
+        DRIVER_ADD_COMMAND(cointerra) \
+        DRIVER_ADD_COMMAND(dragonmintT1) \
+        DRIVER_ADD_COMMAND(bm1370) \
+        DRIVER_ADD_COMMAND(hashfast) \
 	DRIVER_ADD_COMMAND(drillbit) \
 	DRIVER_ADD_COMMAND(hashratio) \
 	DRIVER_ADD_COMMAND(icarus) \


### PR DESCRIPTION
## Summary
- implement a minimal driver placeholder for BM1370
- include the new driver in the build system and configuration script
- document `--enable-bm1370` option

## Testing
- `sh ./autogen.sh`