### PR TITLE
Add skeleton BM1370 driver

### DIFF
--- a/docs/BM1370_Design.md
+++ b/docs/BM1370_Design.md
@@ -1,0 +1,33 @@
+# BM1370 Driver Design
+
+This document outlines the high level design of the BM1370 driver included in
+`cgminer`.  The implementation is heavily inspired by the `driver-btm-soc.c`
+code and the reference implementation found in `reference/ESP-Miner`.
+
+## Communication model
+
+The BM1370 ASICs are connected over a UART interface.  Each packet begins with a
+`0x55AA` preamble followed by a command byte and payload.  Command packets use a
+CRC5 checksum while job packets use a CRC16 checksum.  The driver configures the
+UART at 115200 baud and writes raw packets directly to the device node.
+
+Only a minimal subset of the command set is implemented:
+
+* Set version mask
+* Mark the chain as inactive
+
+The structures and CRC routines are copied from the reference code so the packet
+format matches Bitmain's documentation.
+
+## Device detection
+
+Detection simply attempts to open `/dev/ttyUSB0`.  If successful, a new
+`cgpu_info` instance is created and added to cgminer.  This keeps the driver
+self contained and avoids complex USB enumeration code.
+
+## Limitations
+
+This driver is intentionally lightweight.  It does not yet implement frequency
+configuration, nonce polling or error handling beyond basic send failures.  It
+serves as a starting point for further development when real hardware is
+available.

--- a/docs/BM1370_User.md
+++ b/docs/BM1370_User.md
@@ -1,0 +1,23 @@
+# BM1370 Driver Usage
+
+The BM1370 driver is compiled optionally.  Configure cgminer with the following
+flag:
+
+```sh
+./configure --enable-bm1370
+```
+
+Once built, run cgminer as normal.  The driver will attempt to open
+`/dev/ttyUSB0` on startup.  If the device is present you will see a log message
+similar to:
+
+```
+BM1370: detected at /dev/ttyUSB0
+```
+
+At this stage only basic initialisation commands are sent to the ASIC.  Work can
+be dispatched but nonce reporting has not yet been implemented.  The driver is
+therefore suitable for development and experimentation only.
+
+To change the device path or extend the protocol refer to the source files
+`driver-bm1370.c` and `driver-btm-soc.c` for guidance.

--- a/driver-bm1370.c
+++ b/driver-bm1370.c
@@ -3,16 +3,202 @@
 #include "logging.h"
 #include "driver-bm1370.h"
 
+#include <fcntl.h>
+#include <unistd.h>
+#include <termios.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
 /*
- * Stub driver for BM1370 ASIC based on ESP-Miner reference implementation.
- * This only implements minimal hooks required by cgminer and does not
- * support real hardware interaction. It serves as a placeholder for future
- * development.
+ * Minimal BM1370 driver built from the ESP-Miner reference implementation.
+ * This driver communicates with a BM1370 ASIC chain via a UART interface.
+ * It only implements a very small subset of the protocol sufficient for
+ * experimentation and testing.  The implementation is deliberately simple
+ * and is not intended for production use.
  */
+
+/* ---------------------------------------------------------------------- */
+/* UART helpers                                                           */
+/* ---------------------------------------------------------------------- */
+
+static bool bm1370_uart_open(struct bm1370_info *info, const char *dev)
+{
+    struct termios tio;
+
+    info->uart.fd = open(dev, O_RDWR | O_NOCTTY | O_SYNC);
+    if (info->uart.fd < 0) {
+        applog(LOG_ERR, "BM1370: failed to open %s: %s", dev, strerror(errno));
+        return false;
+    }
+
+    memset(&tio, 0, sizeof(tio));
+    tio.c_cflag = B115200 | CS8 | CLOCAL | CREAD;
+    tio.c_iflag = IGNPAR;
+    tio.c_oflag = 0;
+    tio.c_lflag = 0;
+    tio.c_cc[VTIME] = 0;
+    tio.c_cc[VMIN]  = 1;
+
+    if (tcflush(info->uart.fd, TCIOFLUSH) < 0)
+        applog(LOG_ERR, "BM1370: tcflush failed: %s", strerror(errno));
+    if (tcsetattr(info->uart.fd, TCSANOW, &tio) < 0) {
+        applog(LOG_ERR, "BM1370: tcsetattr failed: %s", strerror(errno));
+        close(info->uart.fd);
+        return false;
+    }
+
+    info->uart.device = strdup(dev);
+    return true;
+}
+
+static void bm1370_uart_close(struct bm1370_info *info)
+{
+    if (info->uart.fd > 0)
+        close(info->uart.fd);
+    free(info->uart.device);
+}
+
+/* ---------------------------------------------------------------------- */
+/* CRC helpers copied from reference/ESP-Miner                            */
+/* ---------------------------------------------------------------------- */
+
+static uint8_t crc5(uint8_t *data, uint8_t len)
+{
+    uint8_t i, j, k, index = 0;
+    uint8_t crc = 0x1F;
+    uint8_t crcin[5] = {1,1,1,1,1};
+    uint8_t crcout[5] = {1,1,1,1,1};
+    uint8_t din = 0;
+
+    len *= 8;
+    for (j = 0x80, k = 0, i = 0; i < len; i++) {
+        din = (data[index] & j) != 0;
+        crcout[0] = crcin[4] ^ din;
+        crcout[1] = crcin[0];
+        crcout[2] = crcin[1] ^ crcin[4] ^ din;
+        crcout[3] = crcin[2];
+        crcout[4] = crcin[3];
+        j >>= 1; k++;
+        if (k == 8) { j = 0x80; k = 0; index++; }
+        memcpy(crcin, crcout, 5);
+    }
+    crc = 0;
+    if (crcin[4]) crc |= 0x10;
+    if (crcin[3]) crc |= 0x08;
+    if (crcin[2]) crc |= 0x04;
+    if (crcin[1]) crc |= 0x02;
+    if (crcin[0]) crc |= 0x01;
+    return crc;
+}
+
+static const uint16_t crc16_table[256] = {
+#include "crc16.c"
+};
+
+static uint16_t crc16_false(uint8_t *buffer, uint16_t len)
+{
+    uint16_t crc = 0xffff;
+    while (len-- > 0)
+        crc = crc16_table[((crc >> 8) ^ (*buffer++)) & 0xFF] ^ (crc << 8);
+    return crc;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Protocol helpers                                                       */
+/* ---------------------------------------------------------------------- */
+
+#define TYPE_JOB   0x20
+#define TYPE_CMD   0x40
+#define GROUP_SINGLE 0x00
+#define GROUP_ALL    0x10
+#define CMD_WRITE 0x01
+#define CMD_READ  0x02
+#define CMD_SETADDRESS 0x00
+#define CMD_INACTIVE 0x03
+
+static int bm1370_send_packet(struct bm1370_info *info, uint8_t header,
+                              const uint8_t *data, uint8_t data_len)
+{
+    bool job = header & TYPE_JOB;
+    uint8_t total = job ? data_len + 6 : data_len + 5;
+    uint8_t buf[64];
+
+    buf[0] = 0x55;
+    buf[1] = 0xAA;
+    buf[2] = header;
+    buf[3] = job ? (data_len + 4) : (data_len + 3);
+    memcpy(buf + 4, data, data_len);
+
+    if (job) {
+        uint16_t crc = crc16_false(buf + 2, data_len + 2);
+        buf[4 + data_len] = (crc >> 8) & 0xFF;
+        buf[5 + data_len] = crc & 0xFF;
+    } else {
+        buf[4 + data_len] = crc5(buf + 2, data_len + 2);
+    }
+
+    if (write(info->uart.fd, buf, total) != total) {
+        applog(LOG_ERR, "BM1370: failed to send packet: %s", strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+/* basic init based on reference implementation */
+static bool bm1370_hw_init(struct bm1370_info *info)
+{
+    uint8_t cmd[6];
+
+    /* set version mask to 0 (default) */
+    cmd[0] = 0x00; cmd[1] = 0xA4; cmd[2] = 0x90; cmd[3] = 0x00; cmd[4] = 0x00; cmd[5] = 0x00;
+    bm1370_send_packet(info, TYPE_CMD | GROUP_ALL | CMD_WRITE, cmd, 6);
+
+    /* put chain inactive */
+    cmd[0] = 0x00; cmd[1] = 0x00;
+    bm1370_send_packet(info, TYPE_CMD | GROUP_ALL | CMD_INACTIVE, cmd, 2);
+
+    return true;
+}
+
+/* ---------------------------------------------------------------------- */
+/* cgminer driver hooks                                                   */
+/* ---------------------------------------------------------------------- */
+
+static struct cgpu_info *bm1370_detect_one(const char *path)
+{
+    struct cgpu_info *cgpu = usb_alloc_cgpu(&bm1370_drv, 1);
+    struct bm1370_info *info;
+
+    if (!cgpu)
+        return NULL;
+
+    info = cgcalloc(1, sizeof(*info));
+    cgpu->device_data = info;
+    cgpu->device_path = strdup(path);
+
+    if (!bm1370_uart_open(info, path))
+        goto fail;
+
+    bm1370_hw_init(info);
+
+    if (!add_cgpu(cgpu))
+        goto fail;
+
+    applog(LOG_INFO, "BM1370: detected at %s", path);
+    return cgpu;
+
+fail:
+    bm1370_uart_close(info);
+    free(info);
+    cgpu = usb_free_cgpu(cgpu);
+    return NULL;
+}
 
 static void bm1370_detect(__maybe_unused bool hotplug)
 {
-    applog(LOG_INFO, "BM1370 driver stub loaded");
+    bm1370_detect_one("/dev/ttyUSB0");
 }
 
 struct device_drv bm1370_drv = {

--- a/driver-bm1370.h
+++ b/driver-bm1370.h
@@ -2,5 +2,14 @@
 #define DRIVER_BM1370_H
 
 #include "miner.h"
+#include "bf16-uartdevice.h"
+
+struct bm1370_info {
+    device_t uart;
+    int frequency;
+    int asic_count;
+};
+
+extern struct device_drv bm1370_drv;
 
 #endif // DRIVER_BM1370_H


### PR DESCRIPTION
## Summary
- implement a basic UART based driver for BM1370 ASICs
- document design details
- document how to enable and run the driver

## Testing
- `./autogen.sh`